### PR TITLE
Return physionet_2012 dataset as three separated sets

### DIFF
--- a/tsdb/loading_funcs/physionet_2012.py
+++ b/tsdb/loading_funcs/physionet_2012.py
@@ -56,12 +56,11 @@ def load_physionet2012(local_path):
         )  # ensure RecordID's type is int
         outcome = outcome.set_index("RecordID")
         outcome_collector.append(outcome)
-    y = pd.concat(outcome_collector)
-
-    df_collector = []
 
     # iterate over all samples
+    set_collector = []
     for m_ in time_series_measurements_dir:
+        df_collector = []
         raw_data_dir = os.path.join(local_path, m_)
         for filename in os.listdir(raw_data_dir):
             recordID = int(filename.split(".txt")[0])
@@ -80,11 +79,16 @@ def load_physionet2012(local_path):
             df_temp["Age"] = df_temp.loc[0, "Age"]
             df_temp["Height"] = df_temp.loc[0, "Height"]
             df_collector.append(df_temp)
+        df = pd.concat(df_collector, sort=True)
+        set_collector.append(df)
 
-    df = pd.concat(df_collector, sort=True)
-    X = df.reset_index(drop=True)
-    unique_ids = df["RecordID"].unique()
-    y = y.loc[unique_ids]
-
-    data = {"X": X, "y": y, "static_features": ["Age", "Gender", "ICUType", "Height"]}
+    data = {
+        "set-a": set_collector[0],
+        "set-b": set_collector[1],
+        "set-c": set_collector[2],
+        "outcomes-a": outcome_collector[0],
+        "outcomes-b": outcome_collector[1],
+        "outcomes-c": outcome_collector[2],
+        "static_features": ["Age", "Gender", "ICUType", "Height"],
+    }
     return data


### PR DESCRIPTION
# What does this PR do?

<!--
Congrats! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution 😉.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, I will review your PR shortly. I may suggest changes to make the code even better 🤝.
-->

<!-- Remove if not applicable -->

Considering the request that users may only need PhysioNet 2012 set a/b/c https://github.com/WenjieDu/PyPOTS/issues/409, we make TSDB return physionet_2012 dataset as three separated sets.


## Before submitting

<!-- You can remove checks that are not relevant to this PR. -->

- [x] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
